### PR TITLE
Fixed colab notebook

### DIFF
--- a/base/invert.py
+++ b/base/invert.py
@@ -3,12 +3,8 @@
 
 import os
 import argparse
-from tqdm import tqdm
-import numpy as np
 
 from utils.inverter import StyleGANInverter
-from utils.logger import setup_logger
-from utils.visualizer import HtmlPageVisualizer
 from utils.visualizer import save_image, load_image, resize_image
 
 def parse_args():
@@ -38,7 +34,7 @@ def parse_args():
   parser.add_argument('--loss_weight_enc', type=float, default=2.0,
                       help='The encoder loss scale for optimization.'
                            '(default: 2.0)')
-  parser.add_argument('--loss_weight_clip', type=float, default=1,
+  parser.add_argument('--loss_weight_clip', type=float, default=2.0,
                       help='The clip loss for optimization. (default: 2.0)')
   parser.add_argument('--gpu_id', type=str, default='0',
                       help='Which GPU(s) to use. (default: `0`)')
@@ -75,6 +71,7 @@ def main():
     image_name = os.path.splitext(os.path.basename(args.image_path))[0]
   else:
     image_name = 'gen'
+  save_image(f'{output_dir}/{image_name}_ori.png', viz_results[0])
   save_image(f'{output_dir}/{image_name}_enc.png', viz_results[1])
   save_image(f'{output_dir}/{image_name}_inv.png', viz_results[-1])
   print(f'save {image_name} in {output_dir}')

--- a/base/streamlit_app.py
+++ b/base/streamlit_app.py
@@ -1,6 +1,4 @@
 import os
-import argparse
-from tqdm import tqdm
 import numpy as np
 from PIL import Image
 import streamlit as st
@@ -8,9 +6,7 @@ import torch
 import clip
 
 from utils.inverter import StyleGANInverter
-from utils.logger import setup_logger
-from utils.visualizer import HtmlPageVisualizer
-from utils.visualizer import save_image, load_image, resize_image
+from utils.visualizer import resize_image
 
 st.title("Text-Guided Editing of Images")
 

--- a/playground.ipynb
+++ b/playground.ipynb
@@ -55,7 +55,7 @@
         "!wget https://mycuhk-my.sharepoint.com/:u:/g/personal/1155082926_link_cuhk_edu_hk/EXqix_JIEgtLl1FXI4uCkr8B5GPaiJyiLXL6cFbdcIKqEA?e=WYesel\\&download\\=1 -O $MODEL_DIR/styleganinv_ffhq256_encoder.pth  --quiet\n",
         "!wget https://mycuhk-my.sharepoint.com/:u:/g/personal/1155082926_link_cuhk_edu_hk/EbuzMQ3ZLl1AqvKJzeeBq7IBoQD-C1LfMIC8USlmOMPt3Q?e=CMXn8W\\&download\\=1 -O $MODEL_DIR/styleganinv_ffhq256_generator.pth  --quiet\n",
         "!wget https://mycuhk-my.sharepoint.com/:u:/g/personal/1155082926_link_cuhk_edu_hk/EQJUz9DInbxEnp0aomkGGzAB5b3ZZbtsOA-TXct9E4ONqA?e=smtO0T\\&download\\=1 -O $MODEL_DIR/vgg16.pth  --quiet\n",
-        "!nvidia-smi\n"
+        "!nvidia-smi"
       ],
       "execution_count": 1,
       "outputs": [
@@ -168,12 +168,11 @@
         "id": "Joi23eZsWi1e"
       },
       "source": [
-        "model='styleganinv_ffhq256'#@param {type:\"string\"}\n",
-        "description='he is old' #@param {type:\"string\"}\n",
-        "loss_weight_clip=2.0 #@param {type:\"number\"}\n",
-        "learning_rate=0.01 #@param {type:\"number\"}\n",
-        "num_iterations=200 #@param {type:\"number\"}\n",
-        "reconstruction_loss_weight=1.0 #@param {type:\"number\"}\n"
+        "model_name = 'styleganinv_ffhq256'  #@param {type:\"string\"}\n",
+        "description = 'he is old'  #@param {type:\"string\"}\n",
+        "loss_weight_clip = 2.0  #@param {type:\"number\"}\n",
+        "learning_rate = 0.01  #@param {type:\"number\"}\n",
+        "num_iterations = 200  #@param {type:\"integer\"}"
       ],
       "execution_count": 3,
       "outputs": []
@@ -188,7 +187,13 @@
         "outputId": "2d279c48-d2e9-403e-e527-e11400414e0d"
       },
       "source": [
-        "!python invert.py --mode='man' --description='he is old'"
+        "!python invert.py \\\n",
+        "  --model_name={model_name} \\\n",
+        "  --mode='man' \\\n",
+        "  --description=f'{description}' \\\n",
+        "  --learning_rate={learning_rate} \\\n",
+        "  --num_iterations={num_iterations} \\\n",
+        "  --loss_weight_clip={loss_weight_clip}"
       ],
       "execution_count": 4,
       "outputs": [
@@ -224,10 +229,10 @@
         "import cv2\n",
         "import numpy as np\n",
         "from google.colab.patches import cv2_imshow\n",
-        "original=cv2.imread('results/inversion/test/142_ori.png')\n",
-        "inversion=cv2.imread('results/inversion/test/142_enc.png')\n",
-        "manipulation=cv2.imread('results/inversion/test/142_inv.png')\n",
-        "result = np.hstack([original,inversion,manipulation])\n",
+        "original = cv2.imread('results/inversion/test/142_ori.png')\n",
+        "inversion = cv2.imread('results/inversion/test/142_enc.png')\n",
+        "manipulation = cv2.imread('results/inversion/test/142_inv.png')\n",
+        "result = np.hstack([original, inversion, manipulation])\n",
         "cv2_imshow(result)"
       ],
       "execution_count": null,
@@ -269,7 +274,7 @@
         "%cd ../ext/\n",
         "!wget --load-cookies /tmp/cookies.txt \"https://docs.google.com/uc?export=download&confirm=$(wget --quiet --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate 'https://docs.google.com/uc?export=download&id=117EQglEe1YADCo9b23mGAymxsjD_cE6d' -O- | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\\1\\n/p')&id=117EQglEe1YADCo9b23mGAymxsjD_cE6d\" -O pretrained_models/stylegan2-ffhq-config-f.pt && rm -rf /tmp/cookies.txt\n",
         "!wget --load-cookies /tmp/cookies.txt \"https://docs.google.com/uc?export=download&confirm=$(wget --quiet --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate 'https://docs.google.com/uc?export=download&id=1KZTOX-Rw74nkfSoMXXim_bj31yZMrmUA' -O- | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\\1\\n/p')&id=1KZTOX-Rw74nkfSoMXXim_bj31yZMrmUA\" -O pretrained_models/psp_celebs_sketch_to_face.pt && rm -rf /tmp/cookies.txt\n",
-        "!wget --load-cookies /tmp/cookies.txt \"https://docs.google.com/uc?export=download&confirm=$(wget --quiet --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate 'https://docs.google.com/uc?export=download&id=13Wr0sCIzkQVS6pWPEDlAcY5w1ON8mNWK' -O- | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\\1\\n/p')&id=13Wr0sCIzkQVS6pWPEDlAcY5w1ON8mNWK\" -O pretrained_models/psp_celebs_seg_to_face.pt && rm -rf /tmp/cookies.txt\n"
+        "!wget --load-cookies /tmp/cookies.txt \"https://docs.google.com/uc?export=download&confirm=$(wget --quiet --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate 'https://docs.google.com/uc?export=download&id=13Wr0sCIzkQVS6pWPEDlAcY5w1ON8mNWK' -O- | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\\1\\n/p')&id=13Wr0sCIzkQVS6pWPEDlAcY5w1ON8mNWK\" -O pretrained_models/psp_celebs_seg_to_face.pt && rm -rf /tmp/cookies.txt"
       ],
       "execution_count": 5,
       "outputs": [
@@ -407,7 +412,12 @@
         "outputId": "c2f4d227-f7c9-492e-9250-b56c19da86ce"
       },
       "source": [
-        "!python inference.py --exp_dir=experiment\t--checkpoint_path=pretrained_models/psp_celebs_seg_to_face.pt --data_path=experiment/images/lab  --latent_mask=14,15,16,17 --couple_outputs        "
+        "!python inference.py \\\n",
+        "  --exp_dir=experiment \\\n",
+        "  --checkpoint_path=pretrained_models/psp_celebs_seg_to_face.pt \\\n",
+        "  --data_path=experiment/images/lab \\\n",
+        "  --latent_mask=14,15,16,17 \\\n",
+        "  --couple_outputs"
       ],
       "execution_count": 7,
       "outputs": [
@@ -434,7 +444,11 @@
         "outputId": "7fb2571d-ad1b-4c14-b7d1-6f32d68c1aa8"
       },
       "source": [
-        "!python demo.py --description='he is a young man' --mode='man' --step=500 --f_oom=False"
+        "!python demo.py \\\n",
+        "  --description='he is a young man' \\\n",
+        "  --mode='man' \\\n",
+        "  --step=500 \\\n",
+        "  --f_oom=False"
       ],
       "execution_count": null,
       "outputs": [
@@ -458,9 +472,7 @@
         "outputId": "ed189853-3195-4cb8-ee2c-96e0f9164ed3"
       },
       "source": [
-        "import cv2\n",
-        "from google.colab.patches import cv2_imshow\n",
-        "result=cv2.imread('experiment/inference_coupled/input_label.png')\n",
+        "result = cv2.imread('experiment/inference_coupled/input_label.png')\n",
         "cv2_imshow(result)"
       ],
       "execution_count": null,
@@ -498,7 +510,11 @@
         "outputId": "7b11027b-185c-412c-dcf3-d4e5cfa00e35"
       },
       "source": [
-        "!python demo.py --description='he is a young man' --mode='man' --step=500 --f_oom=True"
+        "!python demo.py \\\n",
+        "  --description='he is a young man' \\\n",
+        "  --mode='man' \\\n",
+        "  --step=500 \\\n",
+        "  --f_oom=True"
       ],
       "execution_count": null,
       "outputs": [
@@ -523,9 +539,7 @@
         "outputId": "53a2ceef-0d76-4cc0-81a8-1307e7fa8dec"
       },
       "source": [
-        "import cv2\n",
-        "from google.colab.patches import cv2_imshow\n",
-        "result=cv2.imread('experiment/inference_coupled/input_label.png')\n",
+        "result = cv2.imread('experiment/inference_coupled/input_label.png')\n",
         "cv2_imshow(result)"
       ],
       "execution_count": null,


### PR DESCRIPTION
Hi!
Fixed `playground.ipynb` notebook:
- added cmd parameters to `!python invert.py ...` calling: parameters, they were selected above in form;
- original image wasn't save: and when calling `original = cv2.imread('results/inversion/test/142_ori.png')`  file `142_ori.png` was missed.

In ` base/invert.py`:
- added saving original image `save_image(f'{output_dir}/{image_name}_ori.png', viz_results[0])`;
- made default value of `loss_weight_clip` as in description;
- removed unused imports.

Removed unused imports in `base/streamlit_app.py`.