### PR TITLE
Fix link to replicate.ai demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Contact: weihaox AT outlook dot com
 
 ## Update
 
-[2021/8/28] add an [online demo](https://replicate.ai/weihaox/tedigan) implemented by @[bfirsh](https://github.com/bfirsh). This demo uses an open source tool called [Cog](https://github.com/replicate/cog).
+[2021/8/28] add an [online demo](https://replicate.ai/iigroup/tedigan) implemented by @[bfirsh](https://github.com/bfirsh). This demo uses an open source tool called [Cog](https://github.com/replicate/cog).
 
 [2021/4/20] add extended paper.
 


### PR DESCRIPTION
Hi @weihaox 👋🏼 

This is a tiny cleanup PR. I noticed that the README currently has links to two different versions of the demo on Replicate.ai. This PR updates the links to make https://replicate.ai/iigroup/tedigan the canonical model.

cc @bfirsh 